### PR TITLE
Merge dependabot dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "jest-junit": "^16.0.0",
         "lint-staged": "^16.2.7",
         "nock": "^14.0.10",
-        "prettier": "^3.5.3",
+        "prettier": "^3.7.4",
         "semantic-release": "^25.0.2",
         "ts-jest": "^29.4.5",
         "ts-node": "^10.9.1",
@@ -12554,9 +12554,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "jest-junit": "^16.0.0",
     "lint-staged": "^16.2.7",
     "nock": "^14.0.10",
-    "prettier": "^3.5.3",
+    "prettier": "^3.7.4",
     "semantic-release": "^25.0.2",
     "ts-jest": "^29.4.5",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates runtime and dev dependencies, notably `winston` and the semantic-release/tooling stack, and refreshes the lockfile to newer npm ecosystem versions.
> 
> - **Dependencies**:
>   - **Runtime**: Bump `winston` to `^3.19.0`.
>   - **Dev/Tooling**:
>     - Upgrade `semantic-release` to `^25.0.2` (with related plugins and Octokit stack updates).
>     - Update `prettier` to `^3.7.4`.
>     - Update ESLint TypeScript tooling: `@typescript-eslint/{eslint-plugin,parser}` to `^8.48.1`.
> - **Lockfile**:
>   - Refreshes `package-lock.json` with widespread version updates (e.g., npm `11.x`, Octokit, `read-package-up`, `normalize-package-data`, `undici`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cdd3abbf39678482c2e08bcc3d236d03185690c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->