### PR TITLE
feat: add ImpersonationResourceID header support

### DIFF
--- a/src/client/AutotaskClient.ts
+++ b/src/client/AutotaskClient.ts
@@ -410,6 +410,9 @@ export class AutotaskClient {
         ApiIntegrationCode: config.integrationCode,
         UserName: config.username,
         Secret: config.secret,
+        ...(config.impersonateResourceId && {
+          ImpersonationResourceID: String(config.impersonateResourceId),
+        }),
       },
       transformRequest: [
         (data, headers) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface AutotaskAuth {
   secret: string;
   apiUrl?: string; // Optional override
   skipConnectionTest?: boolean; // Skip the /Version connectivity check (useful in gateway/stateless mode)
+  impersonateResourceId?: number; // Optional: Autotask Resource ID to impersonate (ImpersonationResourceID header)
 }
 
 /**

--- a/test/authentication/auth-headers.test.ts
+++ b/test/authentication/auth-headers.test.ts
@@ -3,117 +3,117 @@ import { AutotaskClient } from '../../src/client/AutotaskClient';
 
 /**
  * Test file to verify proper authentication headers are being used
- * 
+ *
  * Autotask API requires three specific headers for authentication:
  * - ApiIntegrationCode: The integration code from Autotask
  * - UserName: The username (email)
  * - Secret: The API secret/password
- * 
+ *
  * This replaces the incorrect Basic Auth implementation
  */
 
 describe('Autotask Authentication Headers', () => {
   it('should use correct authentication headers (not Basic Auth)', async () => {
     const mockAxiosCreate = jest.spyOn(axios, 'create');
-    
+
     // Mock the zone detection call
     jest.spyOn(axios, 'get').mockResolvedValueOnce({
       data: {
-        url: 'https://webservices14.autotask.net/ATServicesRest/'
-      }
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
     });
-    
+
     // Mock the test connection call
     mockAxiosCreate.mockReturnValue({
       get: jest.fn().mockResolvedValue({ data: {} }),
       defaults: { headers: { common: {} } },
       interceptors: {
         request: {
-          use: jest.fn()
+          use: jest.fn(),
         },
         response: {
-          use: jest.fn()
-        }
-      }
+          use: jest.fn(),
+        },
+      },
     } as any);
-    
+
     const config = {
       username: 'test@example.com',
       integrationCode: 'TEST_INTEGRATION_CODE',
-      secret: 'TEST_SECRET'
+      secret: 'TEST_SECRET',
     };
-    
+
     await AutotaskClient.create(config);
-    
+
     // Verify axios.create was called with correct headers
     expect(mockAxiosCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         headers: expect.objectContaining({
           'Content-Type': 'application/json',
-          'ApiIntegrationCode': 'TEST_INTEGRATION_CODE',
-          'UserName': 'test@example.com',
-          'Secret': 'TEST_SECRET'
-        })
+          ApiIntegrationCode: 'TEST_INTEGRATION_CODE',
+          UserName: 'test@example.com',
+          Secret: 'TEST_SECRET',
+        }),
       })
     );
-    
+
     // Verify NO Basic Auth header is present
     const createCall = mockAxiosCreate.mock.calls[0];
     if (createCall && createCall[0]) {
       expect(createCall[0].headers).not.toHaveProperty('Authorization');
-      
+
       // Verify the old incorrect header name is not used
       expect(createCall[0].headers).not.toHaveProperty('ApiIntegrationcode'); // lowercase 'c'
     }
   });
-  
+
   it('should properly encode username in zone detection URL', async () => {
     const mockAxiosGet = jest.spyOn(axios, 'get');
-    
+
     // Mock the zone detection response
     mockAxiosGet.mockResolvedValueOnce({
       data: {
-        url: 'https://webservices14.autotask.net/ATServicesRest/'
-      }
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
     });
-    
+
     // Mock axios.create for the main client
     jest.spyOn(axios, 'create').mockReturnValue({
       get: jest.fn().mockResolvedValue({ data: {} }),
       defaults: { headers: { common: {} } },
       interceptors: {
         request: {
-          use: jest.fn()
+          use: jest.fn(),
         },
         response: {
-          use: jest.fn()
-        }
-      }
+          use: jest.fn(),
+        },
+      },
     } as any);
-    
+
     const config = {
       username: 'user+test@example.com', // Username with special character
       integrationCode: 'TEST_CODE',
-      secret: 'TEST_SECRET'
+      secret: 'TEST_SECRET',
     };
-    
+
     await AutotaskClient.create(config);
-    
+
     // Verify the zone detection URL properly encodes the username
     expect(mockAxiosGet).toHaveBeenCalledWith(
       'https://webservices.autotask.net/ATServicesRest/V1.0/zoneInformation?user=user%2Btest%40example.com'
     );
   });
-  
+
   it('should handle authentication with all required headers in requests', () => {
     // This test verifies the format matches Autotask's requirements
     const expectedHeaders = {
       'Content-Type': 'application/json',
-      'ApiIntegrationCode': 'YOUR_INTEGRATION_CODE',
-      'UserName': 'your.email@domain.com',
-      'Secret': 'YOUR_SECRET'
+      ApiIntegrationCode: 'YOUR_INTEGRATION_CODE',
+      UserName: 'your.email@domain.com',
+      Secret: 'YOUR_SECRET',
     };
-    
+
     // Example curl command that should be equivalent:
     const _curlCommand = `
       curl --location 'https://webservices14.autotask.net/atservicesrest/v1.0/CompanyCategories' \\
@@ -122,11 +122,81 @@ describe('Autotask Authentication Headers', () => {
       --header 'Secret: YOUR_SECRET' \\
       --header 'Content-Type: application/json'
     `.trim();
-    
+
     // The headers object should match exactly what Autotask expects
     expect(expectedHeaders).toHaveProperty('ApiIntegrationCode');
     expect(expectedHeaders).toHaveProperty('UserName');
     expect(expectedHeaders).toHaveProperty('Secret');
     expect(expectedHeaders).not.toHaveProperty('Authorization');
+  });
+
+  it('should include ImpersonationResourceID header when impersonateResourceId is provided', async () => {
+    const mockAxiosCreate = jest.spyOn(axios, 'create');
+
+    jest.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: {
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
+    });
+
+    mockAxiosCreate.mockReturnValue({
+      get: jest.fn().mockResolvedValue({ data: {} }),
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    } as any);
+
+    const config = {
+      username: 'test@example.com',
+      integrationCode: 'TEST_INTEGRATION_CODE',
+      secret: 'TEST_SECRET',
+      impersonateResourceId: 12345,
+    };
+
+    await AutotaskClient.create(config);
+
+    expect(mockAxiosCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          ImpersonationResourceID: '12345',
+        }),
+      })
+    );
+  });
+
+  it('should NOT include ImpersonationResourceID header when impersonateResourceId is not provided', async () => {
+    const mockAxiosCreate = jest.spyOn(axios, 'create');
+
+    jest.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: {
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
+    });
+
+    mockAxiosCreate.mockReturnValue({
+      get: jest.fn().mockResolvedValue({ data: {} }),
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    } as any);
+
+    const config = {
+      username: 'test@example.com',
+      integrationCode: 'TEST_INTEGRATION_CODE',
+      secret: 'TEST_SECRET',
+    };
+
+    await AutotaskClient.create(config);
+
+    const createCall = mockAxiosCreate.mock.calls[0];
+    if (createCall && createCall[0]) {
+      expect(createCall[0].headers).not.toHaveProperty(
+        'ImpersonationResourceID'
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds optional `impersonateResourceId` field to `AutotaskAuth` config interface
- When provided, includes the `ImpersonationResourceID` header in all Autotask API requests
- Enables performing API actions on behalf of a specific Autotask resource/user

## Context
The Autotask REST API supports an `ImpersonationResourceID` header that allows API calls to be executed as a specific resource. This is essential for:
- **Traceability**: Actions appear as performed by the actual user, not the generic API account
- **Multi-user deployments**: Each user can impersonate their own Autotask resource
- **Audit compliance**: Proper attribution of changes in Autotask

## Changes
- `src/types/index.ts`: Added `impersonateResourceId?: number` to `AutotaskAuth` interface
- `src/client/AutotaskClient.ts`: Conditionally adds `ImpersonationResourceID` header to axios instance when config field is provided
- `test/authentication/auth-headers.test.ts`: Added 2 tests — header present when configured, absent when not

## Usage
```typescript
const client = await AutotaskClient.create({
  username: 'api@company.com',
  integrationCode: 'CODE',
  secret: 'SECRET',
  impersonateResourceId: 29683  // Autotask Resource ID
});
```

## Test plan
- [x] Existing auth header tests still pass (5/5)
- [x] New test: ImpersonationResourceID header present when `impersonateResourceId` is set
- [x] New test: ImpersonationResourceID header absent when `impersonateResourceId` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)