### PR TITLE
fix(ci): skip integration tests when secrets unavailable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
       time: "09:00"
     open-pull-requests-limit: 10
     reviewers:
-      - "your-username"
+      - "asachs01"
     assignees:
-      - "your-username"
+      - "asachs01"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
@@ -19,6 +19,9 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    ignore:
+      # No patched version available upstream as of 2026-05-07
+      - dependency-name: "ip-address"
     
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -29,9 +32,9 @@ updates:
       time: "09:00"
     open-pull-requests-limit: 5
     reviewers:
-      - "your-username"
+      - "asachs01"
     assignees:
-      - "your-username"
+      - "asachs01"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,20 @@ jobs:
           AUTOTASK_INTEGRATION_CODE: ${{ secrets.AUTOTASK_INTEGRATION_CODE }}
           AUTOTASK_SECRET: ${{ secrets.AUTOTASK_SECRET }}
 
+      - name: Detect integration secrets
+        id: detect-secrets
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.AUTOTASK_USERNAME }}" ] && [ -n "${{ secrets.AUTOTASK_SECRET }}" ] && [ -n "${{ secrets.AUTOTASK_INTEGRATION_CODE }}" ]; then
+            echo "HAS_AUTOTASK_SECRETS=true" >> "$GITHUB_ENV"
+          else
+            echo "HAS_AUTOTASK_SECRETS=false" >> "$GITHUB_ENV"
+            echo "::notice::Skipping integration tests — Autotask secrets not configured for this run"
+          fi
+
       - name: Run integration tests
+        # Skip integration tests when secrets are unavailable (forks, dependabot PRs)
+        if: ${{ env.HAS_AUTOTASK_SECRETS == 'true' }}
         env:
           NODE_OPTIONS: --max-old-space-size=4096
           AUTOTASK_USERNAME: ${{ secrets.AUTOTASK_USERNAME }}


### PR DESCRIPTION
## Summary

Two related fixes:

### 1. Gate integration tests on secret presence
The `Run integration tests` step in `.github/workflows/ci.yml` always runs, even when secrets aren't available (e.g. dependabot PRs, fork PRs). Tests then fail with `NetworkError: Connection failed` because they can't reach the Autotask API. Now skipped cleanly when any of the three secrets is empty.

### 2. dependabot.yml cleanup
- Replace placeholder `your-username` with @asachs01
- Ignore the `ip-address` security advisory — no upstream patch available

## Why
This was the "every dependabot PR fails on Node 22" pattern from the fleet CI failure survey.