### PR TITLE
fix(test): fake-timers for real-timer retry tests — fixes CI timeout + 3 latent flakes

### DIFF
--- a/test/errors/RecoveryStrategies.test.ts
+++ b/test/errors/RecoveryStrategies.test.ts
@@ -12,9 +12,13 @@ import {
   ErrorRecoveryHandler,
   WithRecovery,
   withRecovery,
-  FeatureFlag
+  FeatureFlag,
 } from '../../src/errors/RecoveryStrategies';
-import { AutotaskError, NetworkError, TimeoutError } from '../../src/errors/AutotaskErrors';
+import {
+  AutotaskError,
+  NetworkError,
+  TimeoutError,
+} from '../../src/errors/AutotaskErrors';
 import { RetryStrategy } from '../../src/errors/RetryStrategy';
 
 describe('RecoveryStrategies', () => {
@@ -28,9 +32,16 @@ describe('RecoveryStrategies', () => {
       maxAttempts: 3,
       metadata: {
         userId: 'user123',
-        correlationId: 'test-correlation-id'
-      }
+        correlationId: 'test-correlation-id',
+      },
     };
+  });
+
+  // Restore real timers after any test that opts into fake timers (the
+  // withRecovery retry-path tests below). Without this, a fake-timer test
+  // would leak its clock into subsequent tests in this file.
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe('RetryRecoveryStrategy', () => {
@@ -41,7 +52,7 @@ describe('RecoveryStrategies', () => {
         maxRetries: 3,
         initialDelay: 100,
         backoffMultiplier: 2,
-        maxDelay: 1000
+        maxDelay: 1000,
       });
       retryStrategy = new RetryRecoveryStrategy(retryStrategyImpl);
     });
@@ -57,14 +68,20 @@ describe('RecoveryStrategies', () => {
     });
 
     it('should not handle non-retryable errors', () => {
-      const validationError = new AutotaskError('Invalid input', 'VALIDATION_ERROR', false);
+      const validationError = new AutotaskError(
+        'Invalid input',
+        'VALIDATION_ERROR',
+        false
+      );
       expect(retryStrategy.canHandle(validationError, mockContext)).toBe(false);
     });
 
     it('should not handle errors that exceed max retries', () => {
       const contextWithRetries = { ...mockContext, attemptCount: 4 };
       const networkError = new NetworkError('Connection failed');
-      expect(retryStrategy.canHandle(networkError, contextWithRetries)).toBe(false);
+      expect(retryStrategy.canHandle(networkError, contextWithRetries)).toBe(
+        false
+      );
     });
 
     it('should return error for retry recovery (needs original operation)', async () => {
@@ -75,7 +92,9 @@ describe('RecoveryStrategies', () => {
       expect(result.strategy).toBe('retry');
       expect(result.isFallback).toBe(false);
       expect(result.error).toBeDefined();
-      expect(result.error?.message).toContain('Retry recovery requires original operation context');
+      expect(result.error?.message).toContain(
+        'Retry recovery requires original operation context'
+      );
     });
   });
 
@@ -87,7 +106,7 @@ describe('RecoveryStrategies', () => {
       mockFallbackProvider = {
         canProvide: jest.fn(),
         getFallback: jest.fn(),
-        name: 'mock-provider'
+        name: 'mock-provider',
       };
       fallbackStrategy = new FallbackRecoveryStrategy(mockFallbackProvider);
     });
@@ -100,7 +119,7 @@ describe('RecoveryStrategies', () => {
     it('should handle errors when provider can provide', () => {
       mockFallbackProvider.canProvide.mockReturnValue(true);
       const error = new NetworkError('Connection failed');
-      
+
       expect(fallbackStrategy.canHandle(error, mockContext)).toBe(true);
       expect(mockFallbackProvider.canProvide).toHaveBeenCalledWith(mockContext);
     });
@@ -108,14 +127,14 @@ describe('RecoveryStrategies', () => {
     it('should not handle errors when provider cannot provide', () => {
       mockFallbackProvider.canProvide.mockReturnValue(false);
       const error = new NetworkError('Connection failed');
-      
+
       expect(fallbackStrategy.canHandle(error, mockContext)).toBe(false);
     });
 
     it('should successfully recover with fallback data', async () => {
       const fallbackData = { name: 'Fallback Data' };
       mockFallbackProvider.getFallback.mockResolvedValue(fallbackData);
-      
+
       const error = new NetworkError('Connection failed');
       const result = await fallbackStrategy.recover(error, mockContext);
 
@@ -129,7 +148,7 @@ describe('RecoveryStrategies', () => {
     it('should handle provider errors gracefully', async () => {
       const providerError = new Error('Provider failed');
       mockFallbackProvider.getFallback.mockRejectedValue(providerError);
-      
+
       const error = new NetworkError('Connection failed');
       const result = await fallbackStrategy.recover(error, mockContext);
 
@@ -168,36 +187,49 @@ describe('RecoveryStrategies', () => {
         _degraded: true,
         operation: 'test-operation',
         message: 'Service temporarily degraded',
-        timestamp: expect.any(String)
+        timestamp: expect.any(String),
       });
       expect(result.metadata?.degradedOperation).toBe('test-operation');
     });
 
     it('should handle different error types appropriately', async () => {
       const timeoutError = new TimeoutError(5000, 'API call');
-      const result = await degradationStrategy.recover(timeoutError, mockContext);
+      const result = await degradationStrategy.recover(
+        timeoutError,
+        mockContext
+      );
 
       expect(result.success).toBe(true);
-      expect(result.metadata?.originalError).toBe('Operation \'API call\' timed out after 5000ms');
+      expect(result.metadata?.originalError).toBe(
+        "Operation 'API call' timed out after 5000ms"
+      );
     });
 
     it('should track degraded features', () => {
-      expect(degradationStrategy.isFeatureDegraded('test-operation')).toBe(false);
-      
+      expect(degradationStrategy.isFeatureDegraded('test-operation')).toBe(
+        false
+      );
+
       const error = new NetworkError('Connection failed');
       degradationStrategy.recover(error, mockContext);
-      
-      expect(degradationStrategy.isFeatureDegraded('test-operation')).toBe(true);
+
+      expect(degradationStrategy.isFeatureDegraded('test-operation')).toBe(
+        true
+      );
     });
 
     it('should restore degraded features', () => {
       const error = new NetworkError('Connection failed');
       degradationStrategy.recover(error, mockContext);
-      
-      expect(degradationStrategy.isFeatureDegraded('test-operation')).toBe(true);
-      
+
+      expect(degradationStrategy.isFeatureDegraded('test-operation')).toBe(
+        true
+      );
+
       degradationStrategy.restoreFeature('test-operation');
-      expect(degradationStrategy.isFeatureDegraded('test-operation')).toBe(false);
+      expect(degradationStrategy.isFeatureDegraded('test-operation')).toBe(
+        false
+      );
     });
   });
 
@@ -215,14 +247,14 @@ describe('RecoveryStrategies', () => {
     it('should provide cached data when available and not expired', () => {
       const cachedData = { name: 'Cached Data' };
       cacheProvider.store(mockContext, cachedData, 60000); // 1 minute TTL
-      
+
       expect(cacheProvider.canProvide(mockContext)).toBe(true);
     });
 
     it('should not provide expired cached data', () => {
       const cachedData = { name: 'Cached Data' };
       cacheProvider.store(mockContext, cachedData, 1); // 1ms TTL
-      
+
       // Wait for expiration
       return new Promise(resolve => {
         setTimeout(() => {
@@ -239,7 +271,7 @@ describe('RecoveryStrategies', () => {
     it('should return cached data', async () => {
       const cachedData = { name: 'Cached Data' };
       cacheProvider.store(mockContext, cachedData, 60000);
-      
+
       const result = await cacheProvider.getFallback(mockContext);
       expect(result).toEqual(cachedData);
     });
@@ -250,10 +282,22 @@ describe('RecoveryStrategies', () => {
     });
 
     it('should generate consistent cache keys', () => {
-      const context1 = { operation: 'test', entityType: 'Entity', parameters: { id: 1 } };
-      const context2 = { operation: 'test', entityType: 'Entity', parameters: { id: 1 } };
-      const context3 = { operation: 'test', entityType: 'Entity', parameters: { id: 2 } };
-      
+      const context1 = {
+        operation: 'test',
+        entityType: 'Entity',
+        parameters: { id: 1 },
+      };
+      const context2 = {
+        operation: 'test',
+        entityType: 'Entity',
+        parameters: { id: 1 },
+      };
+      const context3 = {
+        operation: 'test',
+        entityType: 'Entity',
+        parameters: { id: 2 },
+      };
+
       cacheProvider.store(context1, { data: 'test1' });
       expect(cacheProvider.canProvide(context2)).toBe(true);
       expect(cacheProvider.canProvide(context3)).toBe(false);
@@ -265,8 +309,12 @@ describe('RecoveryStrategies', () => {
 
     beforeEach(() => {
       staticProvider = new StaticDataFallbackProvider();
-      staticProvider.addFallback('test-operation', 'TestEntity', { message: 'Static fallback data' });
-      staticProvider.addFallback('another-operation', 'TestEntity', { message: 'Another static response' });
+      staticProvider.addFallback('test-operation', 'TestEntity', {
+        message: 'Static fallback data',
+      });
+      staticProvider.addFallback('another-operation', 'TestEntity', {
+        message: 'Another static response',
+      });
     });
 
     it('should have correct name', () => {
@@ -294,11 +342,13 @@ describe('RecoveryStrategies', () => {
     });
 
     it('should handle different entity types', () => {
-      staticProvider.addFallback('test-operation', 'DifferentEntity', { message: 'Different entity data' });
-      
+      staticProvider.addFallback('test-operation', 'DifferentEntity', {
+        message: 'Different entity data',
+      });
+
       const context1 = { ...mockContext, entityType: 'TestEntity' };
       const context2 = { ...mockContext, entityType: 'DifferentEntity' };
-      
+
       expect(staticProvider.canProvide(context1)).toBe(true);
       expect(staticProvider.canProvide(context2)).toBe(true);
     });
@@ -309,10 +359,14 @@ describe('RecoveryStrategies', () => {
 
     beforeEach(() => {
       flagManager = new FeatureFlagManager();
-      
+
       flagManager.setFlag({ name: 'feature-a', enabled: true });
       flagManager.setFlag({ name: 'feature-b', enabled: false });
-      flagManager.setFlag({ name: 'percentage-rollout', enabled: true, rollout: 50 });
+      flagManager.setFlag({
+        name: 'percentage-rollout',
+        enabled: true,
+        rollout: 50,
+      });
     });
 
     it('should return correct values for boolean flags', () => {
@@ -328,15 +382,15 @@ describe('RecoveryStrategies', () => {
       // Mock hash function to return consistent values for testing
       const originalHashUserId = (flagManager as any).hashUserId;
       (flagManager as any).hashUserId = jest.fn();
-      
+
       // Hash returns 25 (less than 50% rollout)
       ((flagManager as any).hashUserId as jest.Mock).mockReturnValue(25);
       expect(flagManager.isEnabled('percentage-rollout', 'user1')).toBe(true);
-      
+
       // Hash returns 75 (greater than 50% rollout)
       ((flagManager as any).hashUserId as jest.Mock).mockReturnValue(75);
       expect(flagManager.isEnabled('percentage-rollout', 'user2')).toBe(false);
-      
+
       // Restore original method
       (flagManager as any).hashUserId = originalHashUserId;
     });
@@ -345,9 +399,9 @@ describe('RecoveryStrategies', () => {
       const expiredFlag: FeatureFlag = {
         name: 'expired-feature',
         enabled: false,
-        expiresAt: new Date(Date.now() - 1000) // Expired 1 second ago
+        expiresAt: new Date(Date.now() - 1000), // Expired 1 second ago
       };
-      
+
       flagManager.setFlag(expiredFlag);
       expect(flagManager.isEnabled('expired-feature')).toBe(true); // Should default to enabled when expired
     });
@@ -355,7 +409,7 @@ describe('RecoveryStrategies', () => {
     it('should enable and disable flags', () => {
       flagManager.disable('feature-a');
       expect(flagManager.isEnabled('feature-a')).toBe(false);
-      
+
       flagManager.enable('feature-a');
       expect(flagManager.isEnabled('feature-a')).toBe(true);
     });
@@ -379,26 +433,26 @@ describe('RecoveryStrategies', () => {
 
     beforeEach(() => {
       recoveryHandler = new ErrorRecoveryHandler();
-      
+
       mockRetryStrategy = {
         name: 'retry',
         priority: 100,
         canHandle: jest.fn(),
-        recover: jest.fn()
+        recover: jest.fn(),
       } as any;
 
       mockFallbackStrategy = {
         name: 'fallback',
         priority: 50,
         canHandle: jest.fn(),
-        recover: jest.fn()
+        recover: jest.fn(),
       } as any;
 
       // Clear default strategies and add our mocks
       recoveryHandler.removeStrategy('retry');
       recoveryHandler.removeStrategy('fallback');
       recoveryHandler.removeStrategy('graceful-degradation');
-      
+
       recoveryHandler.addStrategy(mockFallbackStrategy);
       recoveryHandler.addStrategy(mockRetryStrategy);
     });
@@ -414,14 +468,17 @@ describe('RecoveryStrategies', () => {
       mockRetryStrategy.recover.mockResolvedValue({
         success: true,
         strategy: 'retry',
-        isFallback: false
+        isFallback: false,
       });
 
       const error = new NetworkError('Connection failed');
       const result = await recoveryHandler.handleError(error, mockContext);
 
       expect(result.success).toBe(true);
-      expect(mockRetryStrategy.canHandle).toHaveBeenCalledWith(error, mockContext);
+      expect(mockRetryStrategy.canHandle).toHaveBeenCalledWith(
+        error,
+        mockContext
+      );
       // Note: For retry strategy, it uses special handling and won't call recover directly
     });
 
@@ -432,7 +489,7 @@ describe('RecoveryStrategies', () => {
         success: true,
         data: { fallback: 'data' },
         strategy: 'fallback',
-        isFallback: true
+        isFallback: true,
       });
 
       const error = new NetworkError('Connection failed');
@@ -473,14 +530,19 @@ describe('RecoveryStrategies', () => {
 
     it('should handle feature flag disabled operations', async () => {
       const featureFlags = recoveryHandler.getFeatureFlags();
-      featureFlags.setFlag({ name: 'operation:test-operation', enabled: false });
+      featureFlags.setFlag({
+        name: 'operation:test-operation',
+        enabled: false,
+      });
 
       const error = new NetworkError('Connection failed');
       const result = await recoveryHandler.handleError(error, mockContext);
 
       expect(result.success).toBe(false);
       expect(result.strategy).toBe('feature-flag');
-      expect(result.error?.message).toContain('Operation test-operation is currently disabled');
+      expect(result.error?.message).toContain(
+        'Operation test-operation is currently disabled'
+      );
     });
   });
 
@@ -493,30 +555,47 @@ describe('RecoveryStrategies', () => {
   describe('withRecovery utility function', () => {
     it('should use default recovery handler for successful operations', async () => {
       const operation = jest.fn().mockResolvedValue({ success: 'data' });
-      
+
       const result = await withRecovery(operation, mockContext);
-      
+
       expect(result).toEqual({ success: 'data' });
       expect(operation).toHaveBeenCalled();
     });
 
     it('should handle errors with recovery strategies', async () => {
-      const operation = jest.fn().mockRejectedValue(new NetworkError('Connection failed'));
-      
-      const result = await withRecovery(operation, mockContext);
-      
+      // withRecovery runs RetryRecoveryStrategy internally, which uses real
+      // setTimeout for backoff delays — an always-rejecting operation
+      // exhausts the retries with real wall-clock waiting (timeout-prone on
+      // a slow CI runner; this exceeded a 5s per-test timeout locally — the
+      // sibling latent-flake to the RetryStrategy jitter test). Fake timers
+      // patch global setTimeout (covering the internal strategy); runAll
+      // TimersAsync fires the retry cascade instantly. afterEach restores.
+      jest.useFakeTimers();
+      const operation = jest
+        .fn()
+        .mockRejectedValue(new NetworkError('Connection failed'));
+
+      const promise = withRecovery(operation, mockContext);
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
       // Should return degraded response (last resort strategy)
       expect(result).toHaveProperty('_degraded', true);
       expect(result).toHaveProperty('operation', 'test-operation');
     });
 
     it('should handle multiple errors with retry through original operation', async () => {
-      const operation = jest.fn()
+      // Same fake-timer treatment: the retry path uses real backoff delays.
+      jest.useFakeTimers();
+      const operation = jest
+        .fn()
         .mockRejectedValueOnce(new NetworkError('Connection failed'))
         .mockResolvedValueOnce({ success: 'data after retry' });
-      
-      const result = await withRecovery(operation, mockContext);
-      
+
+      const promise = withRecovery(operation, mockContext);
+      await jest.runAllTimersAsync();
+      const result = await promise;
+
       // The retry strategy will retry the original operation and succeed
       expect(result).toEqual({ success: 'data after retry' });
       expect(operation).toHaveBeenCalledTimes(2); // Initial call + 1 retry

--- a/test/errors/RetryStrategy.test.ts
+++ b/test/errors/RetryStrategy.test.ts
@@ -142,6 +142,11 @@ describe('RetryStrategy', () => {
     });
 
     it('should respect max delay', async () => {
+      // Fake timers: with real timers this awaits 500+1000+1000+1000+1000 =
+      // 4500ms of wall-clock. runAllTimersAsync fires the retry-delay
+      // cascade instantly + deterministically (the afterEach restores real
+      // timers). Same pattern as the exponential-backoff test above.
+      jest.useFakeTimers();
       const strategy = new RetryStrategy({
         maxRetries: 5,
         initialDelay: 500,
@@ -155,10 +160,12 @@ describe('RetryStrategy', () => {
         .mockRejectedValue(new NetworkError('Failed'));
       const delays: number[] = [];
 
-      await strategy.execute(operation, {
+      const promise = strategy.execute(operation, {
         onRetry: (error: Error, attempt: number, delay: number) =>
           delays.push(delay),
       });
+      await jest.runAllTimersAsync();
+      await promise;
 
       // 500, 1000, 1000, 1000, 1000 (capped at maxDelay)
       expect(delays).toEqual([500, 1000, 1000, 1000, 1000]);
@@ -167,6 +174,15 @@ describe('RetryStrategy', () => {
 
   describe('Jitter', () => {
     it('should add jitter to prevent thundering herd', async () => {
+      // Fake timers: with real timers this awaits up to 1500+3000+6000 =
+      // ~10.5s of wall-clock — it exceeded the 10s jest testTimeout on the
+      // slower CI runner (passed locally on fast hardware = flaky-by-real-
+      // timer, the root cause of the autotask-node CI RED). The jitter
+      // math (Math.random) still computes real delay VALUES captured via
+      // onRetry; runAllTimersAsync fires the scheduled timers instantly so
+      // we assert the jitter RANGES without waiting. afterEach restores
+      // real timers. Same pattern as the exponential-backoff test above.
+      jest.useFakeTimers();
       const strategy = new RetryStrategy({
         maxRetries: 3,
         initialDelay: 1000,
@@ -179,10 +195,12 @@ describe('RetryStrategy', () => {
         .mockRejectedValue(new NetworkError('Failed'));
       const delays: number[] = [];
 
-      await strategy.execute(operation, {
+      const promise = strategy.execute(operation, {
         onRetry: (error: Error, attempt: number, delay: number) =>
           delays.push(delay),
       });
+      await jest.runAllTimersAsync();
+      await promise;
 
       // With 50% jitter, delays should be within ±50% of base delay
       expect(delays[0]).toBeGreaterThanOrEqual(500); // 1000 - 50%


### PR DESCRIPTION
## Repo-health: fixes the Node 18/20/22 CI RED (unblocks ~10 dependabot bumps)

CI was RED uniformly on Node 18/20/22: `test/errors/RetryStrategy.test.ts:169` *"should add jitter to prevent thundering herd"* threw **"Exceeded timeout of 10000 ms"**. The test awaited REAL backoff delays (initialDelay 1000 × up to +50% jitter over 3 retries = **~10.5s wall-clock**), exceeding jest's 10s `testTimeout` on the slower CI runner. Passed locally on fast hardware — **flaky-by-real-timer**, not a logic bug.

> The ts-jest type warnings in the same job are `diagnostics: { warnOnly: true }` — warnings, not the failure cause. (Grounded from the real CI logs, not the obvious-looking type errors.)

## Address-the-full-set (not just the one CI-failing test)

Swept the whole unit suite under a tight per-test timeout to surface **every** real-timer timeout-prone test, not only today's failure. Found **3 latent siblings** that pass CI's 10s today but would flake on a slower run:
- `RetryStrategy.test.ts` "should respect max delay" (~4.5s real)
- `RecoveryStrategies.test.ts` "withRecovery › should handle errors with recovery strategies" (exceeded a 5s timeout locally)
- `RecoveryStrategies.test.ts` "withRecovery › should handle multiple errors with retry"

## Fix

`jest.useFakeTimers()` + `jest.runAllTimersAsync()` to fire the retry-delay cascade instead of awaiting real wall-clock. The jitter math (`Math.random`) still computes real delay VALUES captured via `onRetry`, so the jitter-range assertions are unchanged — only the WAITING is eliminated. Same pattern the suite already used for the exponential-backoff test. Added `afterEach(useRealTimers)` to `RecoveryStrategies.test.ts` so fake timers don't leak.

## Verification

- `RetryStrategy.test.ts`: 20/20 under a **3s** testTimeout (was >10s)
- `RecoveryStrategies.test.ts`: 46/46 under a **3s** testTimeout
- **Full `npm run test:unit` under a 4s per-test timeout: 1914 pass, 0 fail** — proves the timeout-prone class is fully covered (no remaining real-timer test needs >4s)

Test-only change; no source/runtime changes. Unblocks the ~10 dependabot bumps stuck behind the red Test job.