### PR TITLE
feat: add impersonation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **API impersonation support** - new `impersonationResourceId` config option (or `AUTOTASK_IMPERSONATION_RESOURCE_ID` env var) adds the `ImpersonationResourceId` header to API requests, allowing impersonation of a specific resource.
+
 ### Changed
 
 - Repository hygiene: stopped tracking the generated `dist/` build tree in git (`.gitignore` already excludes it).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ const client = await AutotaskClient.create({
   username: 'your-api-user@domain.com',
   integrationCode: 'YOUR_INTEGRATION_CODE',
   secret: 'YOUR_SECRET',
+  // impersonationResourceId: 12345 // impersonate a resource
 });
 
 // Create a ticket
@@ -189,6 +190,7 @@ The SDK uses Autotask's header-based authentication with three required headers:
 - `ApiIntegrationCode`: Your Autotask API integration code
 - `UserName`: Your API username (email address)
 - `Secret`: Your API secret/password
+- `ImpersonationResourceId` : This header is only set if the `impersonationResourceId` configuration options is included
 
 **Note:** This SDK does NOT use Basic Authentication. All credentials are sent as separate headers as required by the Autotask REST API.
 
@@ -199,6 +201,8 @@ The SDK uses Autotask's header-based authentication with three required headers:
 export AUTOTASK_USERNAME="your-api-user@domain.com"
 export AUTOTASK_INTEGRATION_CODE="YOUR_INTEGRATION_CODE"
 export AUTOTASK_SECRET="YOUR_SECRET"
+# Optional to enable impersonation
+export AUTOTASK_IMPERSONATION_RESOURCE_ID="12345"
 ```
 
 Or create a `.env` file:
@@ -687,6 +691,9 @@ LOG_LEVEL=info
 AUDIT_LOGS_ENABLED=true
 PERFORMANCE_LOGS_ENABLED=true
 SECURITY_LOGS_ENABLED=true
+
+# Impersonation
+AUTOTASK_IMPERSONATION_RESOURCE_ID=RESOURCE_ID
 ```
 
 ### Logging and Debugging
@@ -716,10 +723,10 @@ const client = await AutotaskClient.create({
 
 Autotask enforces two hard limits documented in their [API Rate Limiting guide](https://autotask.net/help/DeveloperHelp/Content/AdminSetup/2ExtensionsIntegrations/APIs/REST/API_Rate_Limiting.htm):
 
-| Limit | Value | Scope |
-|-------|-------|-------|
-| Concurrent threads per endpoint | **3** | Per API tracking identifier |
-| Total requests per hour | **10,000** | Per Autotask tenant database |
+| Limit                           | Value      | Scope                        |
+| ------------------------------- | ---------- | ---------------------------- |
+| Concurrent threads per endpoint | **3**      | Per API tracking identifier  |
+| Total requests per hour         | **10,000** | Per Autotask tenant database |
 
 The SDK automatically respects the 3-thread limit. When more than 3 requests target the same endpoint simultaneously, additional requests are queued and released as slots free up — no 429 errors for concurrency violations.
 
@@ -735,6 +742,7 @@ Team B → integrationCode: TEAM_B_CODE → 3 threads per endpoint (independent)
 ```
 
 To create a dedicated API user:
+
 1. **Admin > Resources (Users) > Resources/Users** → Add Resource
 2. Set Security Level to **API User**
 3. Note the generated credentials (username, secret, integration code)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The SDK uses Autotask's header-based authentication with three required headers:
 - `ApiIntegrationCode`: Your Autotask API integration code
 - `UserName`: Your API username (email address)
 - `Secret`: Your API secret/password
-- `ImpersonationResourceId` : This header is only set if the `impersonationResourceId` configuration options is included
+- `ImpersonationResourceId` : This header is only set if the `impersonationResourceId` configuration option is included
 
 **Note:** This SDK does NOT use Basic Authentication. All credentials are sent as separate headers as required by the Autotask REST API.
 

--- a/src/client/AutotaskClient.ts
+++ b/src/client/AutotaskClient.ts
@@ -281,6 +281,10 @@ export class AutotaskClient {
           process.env.AUTOTASK_API_INTEGRATION_CODE!,
         secret: process.env.AUTOTASK_SECRET || process.env.AUTOTASK_API_SECRET!,
         apiUrl: process.env.AUTOTASK_API_URL,
+        impersonationResourceId:
+          process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID === undefined
+            ? undefined
+            : parseInt(process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID),
       };
 
       if (!config.username || !config.integrationCode || !config.secret) {
@@ -410,6 +414,9 @@ export class AutotaskClient {
         ApiIntegrationCode: config.integrationCode,
         UserName: config.username,
         Secret: config.secret,
+        ...(config.impersonationResourceId && {
+          ImpersonationResourceId: String(config.impersonationResourceId),
+        }),
       },
       transformRequest: [
         (data, headers) => {

--- a/src/client/AutotaskClient.ts
+++ b/src/client/AutotaskClient.ts
@@ -272,6 +272,24 @@ export class AutotaskClient {
 
     // If no config is provided, try to use environment variables
     if (!config) {
+      const rawImpersonationId = process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID;
+      let impersonationResourceId: number | undefined;
+      if (
+        rawImpersonationId !== undefined &&
+        rawImpersonationId.trim() !== ''
+      ) {
+        impersonationResourceId = Number(rawImpersonationId);
+        if (
+          !Number.isInteger(impersonationResourceId) ||
+          impersonationResourceId <= 0
+        ) {
+          throw new ConfigurationError(
+            `AUTOTASK_IMPERSONATION_RESOURCE_ID must be a positive integer, got "${rawImpersonationId}"`,
+            'impersonationResourceId'
+          );
+        }
+      }
+
       // Support both naming conventions for environment variables
       config = {
         username:
@@ -282,9 +300,9 @@ export class AutotaskClient {
         secret: process.env.AUTOTASK_SECRET || process.env.AUTOTASK_API_SECRET!,
         apiUrl: process.env.AUTOTASK_API_URL,
         impersonationResourceId:
-          process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID === undefined
+          impersonationResourceId === undefined
             ? undefined
-            : parseInt(process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID),
+            : impersonationResourceId,
       };
 
       if (!config.username || !config.integrationCode || !config.secret) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface AutotaskAuth {
   secret: string;
   apiUrl?: string; // Optional override
   skipConnectionTest?: boolean; // Skip the /Version connectivity check (useful in gateway/stateless mode)
+  impersonationResourceId?: number; // Optional: Autotask Resource ID to impersonate (ImpersonationResourceId header)
 }
 
 /**

--- a/test/authentication/auth-headers.test.ts
+++ b/test/authentication/auth-headers.test.ts
@@ -3,117 +3,117 @@ import { AutotaskClient } from '../../src/client/AutotaskClient';
 
 /**
  * Test file to verify proper authentication headers are being used
- * 
+ *
  * Autotask API requires three specific headers for authentication:
  * - ApiIntegrationCode: The integration code from Autotask
  * - UserName: The username (email)
  * - Secret: The API secret/password
- * 
+ *
  * This replaces the incorrect Basic Auth implementation
  */
 
 describe('Autotask Authentication Headers', () => {
   it('should use correct authentication headers (not Basic Auth)', async () => {
     const mockAxiosCreate = jest.spyOn(axios, 'create');
-    
+
     // Mock the zone detection call
     jest.spyOn(axios, 'get').mockResolvedValueOnce({
       data: {
-        url: 'https://webservices14.autotask.net/ATServicesRest/'
-      }
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
     });
-    
+
     // Mock the test connection call
     mockAxiosCreate.mockReturnValue({
       get: jest.fn().mockResolvedValue({ data: {} }),
       defaults: { headers: { common: {} } },
       interceptors: {
         request: {
-          use: jest.fn()
+          use: jest.fn(),
         },
         response: {
-          use: jest.fn()
-        }
-      }
+          use: jest.fn(),
+        },
+      },
     } as any);
-    
+
     const config = {
       username: 'test@example.com',
       integrationCode: 'TEST_INTEGRATION_CODE',
-      secret: 'TEST_SECRET'
+      secret: 'TEST_SECRET',
     };
-    
+
     await AutotaskClient.create(config);
-    
+
     // Verify axios.create was called with correct headers
     expect(mockAxiosCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         headers: expect.objectContaining({
           'Content-Type': 'application/json',
-          'ApiIntegrationCode': 'TEST_INTEGRATION_CODE',
-          'UserName': 'test@example.com',
-          'Secret': 'TEST_SECRET'
-        })
+          ApiIntegrationCode: 'TEST_INTEGRATION_CODE',
+          UserName: 'test@example.com',
+          Secret: 'TEST_SECRET',
+        }),
       })
     );
-    
+
     // Verify NO Basic Auth header is present
     const createCall = mockAxiosCreate.mock.calls[0];
     if (createCall && createCall[0]) {
       expect(createCall[0].headers).not.toHaveProperty('Authorization');
-      
+
       // Verify the old incorrect header name is not used
       expect(createCall[0].headers).not.toHaveProperty('ApiIntegrationcode'); // lowercase 'c'
     }
   });
-  
+
   it('should properly encode username in zone detection URL', async () => {
     const mockAxiosGet = jest.spyOn(axios, 'get');
-    
+
     // Mock the zone detection response
     mockAxiosGet.mockResolvedValueOnce({
       data: {
-        url: 'https://webservices14.autotask.net/ATServicesRest/'
-      }
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
     });
-    
+
     // Mock axios.create for the main client
     jest.spyOn(axios, 'create').mockReturnValue({
       get: jest.fn().mockResolvedValue({ data: {} }),
       defaults: { headers: { common: {} } },
       interceptors: {
         request: {
-          use: jest.fn()
+          use: jest.fn(),
         },
         response: {
-          use: jest.fn()
-        }
-      }
+          use: jest.fn(),
+        },
+      },
     } as any);
-    
+
     const config = {
       username: 'user+test@example.com', // Username with special character
       integrationCode: 'TEST_CODE',
-      secret: 'TEST_SECRET'
+      secret: 'TEST_SECRET',
     };
-    
+
     await AutotaskClient.create(config);
-    
+
     // Verify the zone detection URL properly encodes the username
     expect(mockAxiosGet).toHaveBeenCalledWith(
       'https://webservices.autotask.net/ATServicesRest/V1.0/zoneInformation?user=user%2Btest%40example.com'
     );
   });
-  
+
   it('should handle authentication with all required headers in requests', () => {
     // This test verifies the format matches Autotask's requirements
     const expectedHeaders = {
       'Content-Type': 'application/json',
-      'ApiIntegrationCode': 'YOUR_INTEGRATION_CODE',
-      'UserName': 'your.email@domain.com',
-      'Secret': 'YOUR_SECRET'
+      ApiIntegrationCode: 'YOUR_INTEGRATION_CODE',
+      UserName: 'your.email@domain.com',
+      Secret: 'YOUR_SECRET',
     };
-    
+
     // Example curl command that should be equivalent:
     const _curlCommand = `
       curl --location 'https://webservices14.autotask.net/atservicesrest/v1.0/CompanyCategories' \\
@@ -122,11 +122,81 @@ describe('Autotask Authentication Headers', () => {
       --header 'Secret: YOUR_SECRET' \\
       --header 'Content-Type: application/json'
     `.trim();
-    
+
     // The headers object should match exactly what Autotask expects
     expect(expectedHeaders).toHaveProperty('ApiIntegrationCode');
     expect(expectedHeaders).toHaveProperty('UserName');
     expect(expectedHeaders).toHaveProperty('Secret');
     expect(expectedHeaders).not.toHaveProperty('Authorization');
+  });
+
+  it('should include ImpersonationResourceId header when impersonationResourceId is provided', async () => {
+    const mockAxiosCreate = jest.spyOn(axios, 'create');
+
+    jest.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: {
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
+    });
+
+    mockAxiosCreate.mockReturnValue({
+      get: jest.fn().mockResolvedValue({ data: {} }),
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    } as any);
+
+    const config = {
+      username: 'test@example.com',
+      integrationCode: 'TEST_INTEGRATION_CODE',
+      secret: 'TEST_SECRET',
+      impersonationResourceId: 12345,
+    };
+
+    await AutotaskClient.create(config);
+
+    expect(mockAxiosCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          ImpersonationResourceId: '12345',
+        }),
+      })
+    );
+  });
+
+  it('should NOT include ImpersonationResourceId header when impersonationResourceId is not provided', async () => {
+    const mockAxiosCreate = jest.spyOn(axios, 'create');
+
+    jest.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: {
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
+    });
+
+    mockAxiosCreate.mockReturnValue({
+      get: jest.fn().mockResolvedValue({ data: {} }),
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    } as any);
+
+    const config = {
+      username: 'test@example.com',
+      integrationCode: 'TEST_INTEGRATION_CODE',
+      secret: 'TEST_SECRET',
+    };
+
+    await AutotaskClient.create(config);
+
+    const createCall = mockAxiosCreate.mock.calls[0];
+    if (createCall && createCall[0]) {
+      expect(createCall[0].headers).not.toHaveProperty(
+        'ImpersonationResourceId'
+      );
+    }
   });
 });

--- a/test/authentication/auth-headers.test.ts
+++ b/test/authentication/auth-headers.test.ts
@@ -199,4 +199,61 @@ describe('Autotask Authentication Headers', () => {
       );
     }
   });
+
+  it('should properly set include ImpersonationResourceId header when AUTOTASK_IMPERSONATION_RESOURCE_ID env var is provided', async () => {
+    const originalEnv = { ...process.env };
+
+    const mockAxiosCreate = jest.spyOn(axios, 'create');
+
+    jest.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: {
+        url: 'https://webservices14.autotask.net/ATServicesRest/',
+      },
+    });
+
+    mockAxiosCreate.mockReturnValue({
+      get: jest.fn().mockResolvedValue({ data: {} }),
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    } as any);
+
+    try {
+      process.env.AUTOTASK_USERNAME = 'test@example.com';
+      process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID = '12345';
+      process.env.AUTOTASK_INTEGRATION_CODE = 'TEST_INTEGRATION_CODE';
+      process.env.AUTOTASK_SECRET = 'TEST_SECRET';
+
+      await AutotaskClient.create();
+
+      expect(mockAxiosCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            ImpersonationResourceId: '12345',
+          }),
+        })
+      );
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
+  it('should fail if an invalid value for AUTOTASK_IMPERSONATION_RESOURCE_ID env var is provided', async () => {
+    const originalEnv = { ...process.env };
+
+    try {
+      process.env.AUTOTASK_USERNAME = 'test@example.com';
+      process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID = 'not-a-number';
+      process.env.AUTOTASK_INTEGRATION_CODE = 'TEST_INTEGRATION_CODE';
+      process.env.AUTOTASK_SECRET = 'TEST_SECRET';
+
+      await expect(AutotaskClient.create()).rejects.toThrow(
+        'AUTOTASK_IMPERSONATION_RESOURCE_ID must be a positive integer'
+      );
+    } finally {
+      process.env = originalEnv;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

This PR implements the same functionality as PR #156 that was closed without merging with some minor changes to use "impersonation" consistently throughout to match the Autotask header name used and to include env var support.

- Adds optional `impersonationResourceId` field to `AutotaskAuth` config interface
- When provided, includes the `ImpersonationResourceId` header in all Autotask API requests
- Enables performing API actions on behalf of a specific Autotask resource/user

## Changes

- `src/types/index.ts`: Added `impersonationResourceId?: number` to `AutotaskAuth` interface
- `src/client/AutotaskClient.ts`: Conditionally adds `ImpersonationResourceId` header to axios instance when config field is provided or `AUTOTASK_IMPERSONATION_RESOURCE_ID` env var is set

## Testing

- `test/authentication/auth-headers.test.ts`: Added 2 tests - header present when configured, absent when not

## Checklist

- [x] The change is described clearly above and the reason for it is stated.
- [x] Tests were added or updated where it makes sense, and the existing suite passes.
- [x] Documentation (README, comments, CHANGELOG) is updated if behavior changed.
- [x] No secrets, credentials, or tokens are included in the diff.
- [x] The commit messages follow the repository's convention.
