### PR TITLE
chore(deps): group + weekly Dependabot config to cut PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
       production-minor-patch:
         dependency-type: "production"
         update-types: ["minor", "patch"]
+    ignore:
+      # No patched version available upstream as of 2026-05-07
+      - dependency-name: "ip-address"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,43 +1,49 @@
+# Canonical Dependabot config for the wyre-technology fleet.
+#
+# Goal: keep PR volume manageable. Updates are GROUPED so this repo gets a
+# handful of PRs per week instead of one-per-package. The dependabot-janitor
+# (org-level, twice-daily) auto-merges green grouped/minor/patch PRs and
+# dev/CI-tooling majors; runtime majors are held for human review.
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - "asachs01"
-    assignees:
-      - "asachs01"
     commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
+      prefix: "deps"
+      prefix-development: "deps-dev"
       include: "scope"
-    labels:
-      - "dependencies"
-      - "npm"
-    ignore:
-      # No patched version available upstream as of 2026-05-07
-      - dependency-name: "ip-address"
-    
-  # Enable version updates for GitHub Actions
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["major", "minor", "patch"]
+      production-minor-patch:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
     open-pull-requests-limit: 5
-    reviewers:
-      - "asachs01"
-    assignees:
-      - "asachs01"
     commit-message:
-      prefix: "chore"
+      prefix: "ci"
       include: "scope"
-    labels:
-      - "dependencies"
-      - "github-actions" 
+    groups:
+      github-actions:
+        patterns: ["*"]
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "docker"
+      include: "scope"
+    groups:
+      docker:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,15 +35,3 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "docker"
-      include: "scope"
-    groups:
-      docker:
-        patterns: ["*"]


### PR DESCRIPTION
Groups all version updates into one PR per ecosystem (dev-deps incl. majors; production minor/patch; github-actions; docker where applicable), weekly schedule, matches the fleet's existing canonical pattern. Config-only, no runtime impact. Part of the org-wide Dependabot-noise cleanup.