### PR TITLE
ci(deps): ignore typescript major-version bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,14 @@ updates:
     ignore:
       # No patched version available upstream as of 2026-05-07
       - dependency-name: "ip-address"
+      # typescript 7.x breaks this fleet's toolchain: DTS emit (tsup/rollup-plugin-dts
+      # TS5101 baseUrl-deprecated-as-error), and typescript-eslint (still <6.1.0 as of
+      # 8.66.0, no TS7 support yet). Has broken main 3x on some repos because Dependabot
+      # has no memory of a prior manual revert and just re-proposes the same major again.
+      # Deliberate hold, not a permanent blind -- remove once typescript-eslint + the
+      # tsup/DTS toolchain support TS7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why

typescript 7.x breaks this fleet's toolchain:
- DTS emit via tsup/rollup-plugin-dts throws `TS5101` ("baseUrl deprecated") as a hard error.
- `typescript-eslint` still caps its peer range below typescript 6.1.0 as of its latest 8.66.0 release — no TS7 support yet.

Several repos in the fleet have already had this manually fixed once (typescript pinned back down), only for Dependabot to re-propose and re-merge the exact same breaking major bump later, because Dependabot has no memory of a prior manual revert. This broke `main` on 5 repos across the fleet.

## What

Adds a `typescript` semver-major entry to the existing `ignore:` list in `.github/dependabot.yml`, blocking Dependabot from proposing `typescript` major bumps until `typescript-eslint` and the tsup/rollup-plugin-dts toolchain support TS7. This is a deliberate, temporary hold — not a permanent blind — and should be removed once the toolchain catches up.

Config-only change, no application code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-node/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->