### PR TITLE
ci(deps): ignore uuid in dependabot config (fixes EOVERRIDE recreate-job failure)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,18 @@ updates:
       # tsup/DTS toolchain support TS7.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # uuid is force-pinned via package.json's top-level `overrides` (added in #175,
+      # to push the patched ^14.0.0 through bull/exceljs/jest-junit transitives that
+      # otherwise pull an older, vulnerable uuid). npm requires an EXACT string match
+      # between `dependencies.uuid` and `overrides.uuid` for a package that is both a
+      # direct dependency and a top-level override target -- Dependabot's own update
+      # job bumps only the override (to a literal pinned version) without touching the
+      # direct-dependency range in the same pass, which trips npm's EOVERRIDE check
+      # every time ("Override for uuid@X conflicts with direct dependency"), 2026-08-13
+      # and 2026-08-17. Ignoring uuid here stops that recurring job failure; bumping
+      # uuid going forward means manually updating both dependencies.uuid AND
+      # overrides.uuid to the same value in one commit.
+      - dependency-name: "uuid"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Fixes task_1787054902912: Dependabot's production-minor-patch group **recreate job** (not a PR's own CI — the job that scans for updates) has failed with `npm error EOVERRIDE: Override for uuid@14.0.1 conflicts with direct dependency` on every run since 2026-08-13 (reproduced 08-13 and 08-17, [run 32079486810](https://github.com/wyre-technology/autotask-node/actions/runs/32079486810)).
- Root cause: `uuid` is force-pinned via package.json's top-level `overrides` (added in #175, to push the patched `^14.0.0` through `bull`/`exceljs`/`jest-junit` transitives that otherwise pull an older, vulnerable uuid). npm requires an **exact string match** between `dependencies.uuid` and `overrides.uuid` for a package that is both a direct dependency and a top-level override target. Dependabot's update job bumps only the override (to a literal pinned version, e.g. `14.0.1`) without touching the direct-dependency range in the same pass — tripping npm's EOVERRIDE check every time, even though the two ranges are numerically compatible.
- Fix: add `uuid` to the `ignore` list in `.github/dependabot.yml`, same shape as the existing `ip-address`/`typescript` entries. This stops the recurring job failure and the blocked group-PR refresh it was causing. Nothing in `package.json` changes — the override stays in place, still doing its job (uuid is currently `^14.0.0` in both places, consistent, 0 vulnerabilities per `npm audit`).
- Future uuid bumps: update both `dependencies.uuid` and `overrides.uuid` to the same value in one manual commit (same pattern as the original #175 fix), rather than relying on Dependabot.

## Test plan
- [x] Verified this is the actual root cause via the job log (`Error running package manager command: corepack npm install uuid@14.0.1 --package-lock-only --dry-run=true --ignore-scripts, Error: npm error code EOVERRIDE`)
- [x] Confirmed via `git log -S` that #175 introduced both the `dependencies.uuid` bump and the `overrides.uuid` entry together, for a documented security reason (not vestigial — do not just delete the override)
- [x] Validated the edited YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No package.json/package-lock.json changes — this is dependabot-config-only, no build/test impact

🤖 Generated by murph (WYRE mcp-gateway caretaker agent)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-node/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->