### PR TITLE
ci(deps): ignore dependabot bumps to uuid override (EOVERRIDE conflict)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,17 @@ updates:
       # tsup/DTS toolchain support TS7.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # uuid is both a direct dependency AND a top-level override (added in #175 to
+      # force any transitive uuid usage up to the patched v14 line, alongside the
+      # brace-expansion/diff overrides above -- a real security-hardening pin, not
+      # vestigial). npm requires a top-level override for a package that's also a
+      # direct dependency to match EXACTLY, so any Dependabot attempt to bump the
+      # override alone (independent of the dependencies entry) throws EOVERRIDE and
+      # fails the whole production-minor-patch group's recreate job -- reproduced
+      # 2026-08-13 and 2026-08-17 (npm error: "Override for uuid@14.0.1 conflicts
+      # with direct dependency"). Bump uuid manually (both dependencies AND
+      # overrides, same value) instead of via Dependabot.
+      - dependency-name: "uuid"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- `uuid` is both a direct dependency (`^14.0.0`) AND a top-level `overrides` entry (`^14.0.0`), added in #175 as a security-hardening pin forcing any transitive uuid usage up to the patched v14 line (fixes buffer-bounds-check advisories in v3/v5/v6).
- npm requires a top-level override for a package that's also a direct dependency to match **exactly** — so whenever Dependabot's `production-minor-patch` group recreate job tries to bump the override alone (independent of the `dependencies` entry), it throws `EOVERRIDE` and the whole group job fails.
- Reproduced twice: job runs [31700587499](https://github.com/wyre-technology/autotask-node/actions/runs/31700587499) (2026-08-13) and [32079486810](https://github.com/wyre-technology/autotask-node/actions/runs/32079486810) (2026-08-17), both `npm error Override for uuid@14.0.1 conflicts with direct dependency`.
- Fix: add a dependabot `ignore` rule for `uuid`, same shape as the existing `ip-address` rule (hold Dependabot off a package it structurally can't update alone; bump both `dependencies.uuid` and `overrides.uuid` together, manually, when a new version is needed).
- Current `production-minor-patch` group PR (#231) is unaffected by this — this only blocks the recreate/refresh job, not the existing PR.

## Why not just remove the override
The override isn't vestigial — it protects against a future transitive dependency pulling in an old, vulnerable uuid version. Removing it would silently reopen that class of security issue. Holding it in sync manually (this PR) preserves the protection while stopping the recurring CI failure.

## Test plan
- [x] `yaml.safe_load` on the changed file — valid
- [x] No other files touched; not a code change, config-only

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-node/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->