### PR TITLE
fix(security): bump transitive tar 7.5.13 -> 7.5.22 (critical DoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14433,9 +14433,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
## Summary
- Runtime-scope transitive `tar` (via `sqlite3` -> `node-gyp`, and npm's own bundle) was pinned at 7.5.13 in the lockfile despite every requiring range (`^7.4.3`–`^7.5.13`) already permitting the patched version — a stale lockfile, not a manifest constraint.
- Fixes Dependabot alert **#124** (critical: node-tar decompression/parse DoS via unlimited input, `<=7.5.18`, patched `7.5.19+`, [GHSA-23hp-3jrh-7fpw](https://github.com/advisories/GHSA-23hp-3jrh-7fpw)) plus 2 related moderate tar advisories in the same range caught by the same bump.
- Lockfile-only change: `npm update tar`. No `package.json` edit, no code touched.

## Known remaining gap (not fixed here, flagged separately)
npm's own **bundled** tar (`node_modules/npm/node_modules/tar`, `inBundle:true`) still resolves to 7.5.13 — it ships inside `npm@11.13.0` (required by `@semantic-release/npm`) and can't be independently bumped without moving `npm` itself to 12.x, a major version that needs release-pipeline verification before touching. Dev/release-tooling scope only, not the shipped library — tracking as a follow-up, not blocking this fix.

## Test plan
- [x] `npm update tar` — lockfile-only diff (3 lines)
- [x] `npm run build` (`tsc`) — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-node/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->